### PR TITLE
Adding Inflation-adjusted Return calc and test case

### DIFF
--- a/finance.js
+++ b/finance.js
@@ -174,6 +174,11 @@ Finance.prototype.PMT = function(fractionalRate, numOfPayments, principal) {
   return -principal * fractionalRate/(1-Math.pow(1+fractionalRate,-numOfPayments))
 };
 
+// IAR calculates the Inflation-adjusted return
+Finance.prototype.IAR = function(investmentReturn, inflationRate){
+  return 100 * (((1 + investmentReturn) / (1 + inflationRate)) - 1);
+}
+
 if (typeof exports !== 'undefined') {
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = Finance;

--- a/test/index.js
+++ b/test/index.js
@@ -105,5 +105,9 @@ describe('FinanceJS', function() {
     // fractional rate, number of payments, loan principal
     Number(cal.PMT(0.02,36,-1000000).toFixed(4)).should.equal(39232.8526)
   });
+    //investment return, inflation rate
+  it('should compute IAR', function() {
+    cal.IAR(0.08, 0.03).should.equal(4.854368932038833);
+  });
 
 });


### PR DESCRIPTION
Adding Inflation-adjusted return calculator. This calculator is used to calculate 'real return' or return that has been adjusted for inflation